### PR TITLE
Improve the restore experience

### DIFF
--- a/deployment/efs-to-efs-restore.template
+++ b/deployment/efs-to-efs-restore.template
@@ -15,9 +15,9 @@ Parameters:
     Description: Source EFS Id
     Type: String
 
-  # Destination EFS from where restore will be performed
+  # Destination EFS to where restore will be performed
   DstEFS:
-    Description: Backup EFS Id
+    Description: Destination EFS Id
     Type: String
 
   # Interval tag which you want to restore
@@ -117,7 +117,7 @@ Metadata:
       IntervalTag:
         default: Interval Label
       DstEFS:
-        default: Backup EFS
+        default: Destination EFS
       Subnets:
         default: Subnet IDs
       SrcEFS:

--- a/deployment/efs-to-efs-restore.template
+++ b/deployment/efs-to-efs-restore.template
@@ -66,10 +66,14 @@ Parameters:
 
   # List of SubnetIDs for EC2, must be same AZ as of EFS Mount Targets
   Subnets:
-    Description: List of SubnetIDs for EC2, must be same AZ as of EFS Mount Targets(Choose 2)
+    Description: List of SubnetIDs for EC2, must be same AZ as of EFS Mount Targets (Choose 2)
     Type: List<AWS::EC2::Subnet::Id>
     ConstraintDescription: must specify subnets in different AZs
 
+  SecurityGroupId:
+    Description: The ID of an existing EC2 SecurityGroup in your Virtual Private Cloud (VPC), which should provide access to your existing EFS
+    Type: AWS::EC2::SecurityGroup::Id
+  
   # Bucket where restore logs will be saved
   RestoreLogBucket:
     Description: Bucket to store restore logs (use the same bucket as Backup)
@@ -82,7 +86,7 @@ Parameters:
 
   # CW Dashboard
   Dashboard:
-    Description: Do you want dashoard for your metrics?
+    Description: Do you want dashboard for your metrics?
     Type: String
     AllowedValues:
       - "Yes"
@@ -108,6 +112,7 @@ Metadata:
           - InstanceSize
           - Subnets
           - VpcId
+          - SecurityGroupId
       - Label:
           default: Notification & Dashboard
         Parameters:
@@ -132,6 +137,8 @@ Metadata:
         default: Instance Size
       VpcId:
         default: VPC ID
+      SecurityGroupId:
+        default: Security Group ID
       RestoreLogBucket:
         default: Restore Log Bucket
 
@@ -188,6 +195,7 @@ Resources:
       ImageId: !GetAtt AMIInfo.Id
       SecurityGroups:
         - !Sub ${EFSSecurityGroup}
+        - !Ref SecurityGroupId
       InstanceType: !FindInMap [Map, !Ref "AWS::Region", !Ref InstanceSize]
       IamInstanceProfile: !Sub ${InstanceProfile}
       UserData:

--- a/source/scripts/efs-ec2-backup.sh
+++ b/source/scripts/efs-ec2-backup.sh
@@ -44,7 +44,7 @@ echo "instance-id is ${_instance_id}"
 # getting source/destination efs mount ip
 # parameters : [_source_efs, _region]
 #
-echo "-- $(date -u +%FT%T) -- getting efs mount IPs"
+echo "-- $(date -u +%FT%T) -- resolving source address ${_source_efs}.efs.${_region}.amazonaws.com"
 until dig ${_source_efs}.efs.${_region}.amazonaws.com +short
 do
   sleep 1
@@ -52,6 +52,7 @@ done
 _src_mount_ip=$(dig ${_source_efs}.efs.${_region}.amazonaws.com +short)
 echo "-- $(date -u +%FT%T) -- src mount ip: ${_src_mount_ip}"
 
+echo "-- $(date -u +%FT%T) -- resolving destination address ${_destination_efs}.efs.${_region}.amazonaws.com"
 until dig ${_destination_efs}.efs.${_region}.amazonaws.com +short
 do
   sleep 1

--- a/source/scripts/efs-ec2-backup.sh
+++ b/source/scripts/efs-ec2-backup.sh
@@ -34,10 +34,10 @@ echo "_backup_prefix: ${_backup_prefix}"
 #
 # get region and instance-id from instance meta-data
 #
-_az=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone/)
+_az=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone/)
 _region=${_az::-1}
 echo "region is ${_region}"
-_instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+_instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 echo "instance-id is ${_instance_id}"
 
 #

--- a/source/scripts/efs-ec2-restore.sh
+++ b/source/scripts/efs-ec2-restore.sh
@@ -50,6 +50,7 @@ echo "instance-type is ${_instance_type}"
 # getting source/destination efs mount ip
 # parameters : [_source_efs, _region]
 #
+echo "-- $(date -u +%FT%T) -- resolving source address ${_source_efs}.efs.${_region}.amazonaws.com"
 until dig ${_source_efs}.efs.${_region}.amazonaws.com +short
 do
   sleep 1
@@ -57,6 +58,7 @@ done
 _src_mount_ip=$(dig ${_source_efs}.efs.${_region}.amazonaws.com +short)
 echo "-- $(date -u +%FT%T) -- src mount ip: ${_src_mount_ip}"
 
+echo "-- $(date -u +%FT%T) -- resolving destination address ${_destination_efs}.efs.${_region}.amazonaws.com"
 until dig ${_destination_efs}.efs.${_region}.amazonaws.com +short
 do
   sleep 1

--- a/source/scripts/efs-ec2-restore.sh
+++ b/source/scripts/efs-ec2-restore.sh
@@ -38,12 +38,12 @@ echo "_sns_topic: ${_sns_topic}"
 #
 # get region from instance meta-data
 #
-_az=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone/)
+_az=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone/)
 _region=${_az::-1}
 echo "region is ${_region}"
-_instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+_instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 echo "instance-id is ${_instance_id}"
-_instance_type=$(curl http://169.254.169.254/latest/meta-data/instance-type/)
+_instance_type=$(curl -s http://169.254.169.254/latest/meta-data/instance-type/)
 echo "instance-type is ${_instance_type}"
 
 #

--- a/source/scripts/efs-ec2-restore.sh
+++ b/source/scripts/efs-ec2-restore.sh
@@ -2,9 +2,9 @@
 #
 #========================================================================
 #
-# master script to run efs-backup
+# master script to run efs-restore-fpsync
 # fetches EFS mount IPs
-# runs efs-backup scripts
+# runs efs-restore scripts
 # uploads logs to S3
 # updates status on DynamoDB
 #
@@ -13,7 +13,7 @@
 
 
 clear
-echo "This is the master script to perform efs backup"
+echo "This is the master script to perform efs restore"
 sleep 2
 
 _source_efs=$1 ## {type:string, description:source efs id}
@@ -66,13 +66,13 @@ echo "-- $(date -u +%FT%T) -- dst mount ip: ${_dst_mount_ip}"
 
 if [ -z "${_src_mount_ip}" ] || [ -z "${_dst_mount_ip}" ]; then
   echo "-- $(date -u +%FT%T) -- ERROR:efs_mount_ip_not_found"
-  echo "-- $(date -u +%FT%T) -- Either or both mount IPs not found, skipping EFS backup script. Please verify if the EC2 instance was launched in the same AZ as the EFS systems."
+  echo "-- $(date -u +%FT%T) -- Either or both mount IPs not found, skipping EFS restore script. Please verify if the EC2 instance was launched in the same AZ as the EFS systems."
   echo "-- $(date -u +%FT%T) -- Notify customer of failure"
   aws sns publish --region ${_region} \
   --topic-arn ${_sns_topic} \
   --message '{
     SourceEFS:'${_source_efs}',
-    BackupEFS:'${_destination_efs}',
+    DestinationEFS:'${_destination_efs}',
     Interval:'${_interval}',
     BackupNum:'${_backup_num}',
     FolderLabel:'${_folder_label}',
@@ -151,7 +151,7 @@ else
     --topic-arn ${_sns_topic} \
     --message '{
      SourceEFS:'${_source_efs}',
-     BackupEFS:'${_destination_efs}',
+     DestinationEFS:'${_destination_efs}',
      Interval:'${_interval}',
      BackupNum:'${_backup_num}',
      FolderLabel:'${_folder_label}',
@@ -167,7 +167,7 @@ else
     --topic-arn ${_sns_topic} \
     --message '{
      SourceEFS:'${_source_efs}',
-     BackupEFS:'${_destination_efs}',
+     DestinationEFS:'${_destination_efs}',
      Interval:'${_interval}',
      BackupNum:'${_backup_num}',
      FolderLabel:'${_folder_label}',

--- a/source/scripts/efs-restore-fpsync.sh
+++ b/source/scripts/efs-restore-fpsync.sh
@@ -38,8 +38,8 @@ sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 
 echo "-- $(date -u +%FT%T) -- sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $destination /mnt/destination"
 sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $destination /mnt/destination
 
-if [ ! sudo test -d /mnt/backups/$efsid/$interval.$backupNum/ ]; then
-  echo "EFS Backup $efsid/$interval.$backupNum does not exist!"
+if sudo test ! -d "/mnt/backups/$efsid/$interval.$backupNum/"; then
+  echo "EFS Backup /mnt/backups/$efsid/$interval.$backupNum/ does not exist!"
   exit 1
 fi
 

--- a/source/scripts/efs-restore-fpsync.sh
+++ b/source/scripts/efs-restore-fpsync.sh
@@ -29,14 +29,14 @@ sudo make install
 PATH=$PATH:/usr/local/bin
 
 
-echo '-- $(date -u +%FT%T) -- sudo mkdir /backup'
-sudo mkdir /backup
-echo '-- $(date -u +%FT%T) -- sudo mkdir /mnt/backups'
-sudo mkdir /mnt/backups
-echo "-- $(date -u +%FT%T) -- sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $source /backup"
-sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $source /backup
-echo "-- $(date -u +%FT%T) -- sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $destination /mnt/backups"
-sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $destination /mnt/backups
+echo "-- $(date -u +%FT%T) -- sudo mkdir -p /mnt/destination"
+sudo mkdir -p /mnt/destination
+echo "-- $(date -u +%FT%T) -- sudo mkdir -p /mnt/backups"
+sudo mkdir -p /mnt/backups
+echo "-- $(date -u +%FT%T) -- sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $source /mnt/backups"
+sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $source /mnt/backups
+echo "-- $(date -u +%FT%T) -- sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $destination /mnt/destination"
+sudo mount -t nfs -o nfsvers=4.1 -o rsize=1048576 -o wsize=1048576 -o timeo=600 -o retrans=2 -o hard $destination /mnt/destination
 
 if [ ! sudo test -d /mnt/backups/$efsid/$interval.$backupNum/ ]; then
   echo "EFS Backup $efsid/$interval.$backupNum does not exist!"
@@ -70,14 +70,14 @@ fi
 
 # running fpsync in reverse direction to restore
 echo "fpsync_start:$(date -u +%FT%T)"
-echo "-- $(date -u +%FT%T) -- sudo \"PATH=$PATH\" /usr/local/bin/fpsync -n $_thread_count -v -o \"-a --stats --numeric-ids --log-file=/tmp/efs-restore.log\" /mnt/backups/$efsid/$interval.$backupNum/ /backup/"
-sudo "PATH=$PATH" /usr/local/bin/fpsync -n $_thread_count -v -o "-a --stats --numeric-ids --log-file=/tmp/efs-restore.log" /mnt/backups/$efsid/$interval.$backupNum/ /backup/
+echo "-- $(date -u +%FT%T) -- sudo \"PATH=$PATH\" /usr/local/bin/fpsync -n $_thread_count -v -o \"-a --stats --numeric-ids --log-file=/tmp/efs-restore.log\" /mnt/backups/$efsid/$interval.$backupNum/ /mnt/destination/"
+sudo "PATH=$PATH" /usr/local/bin/fpsync -n $_thread_count -v -o "-a --stats --numeric-ids --log-file=/tmp/efs-restore.log" /mnt/backups/$efsid/$interval.$backupNum/ /mnt/destination/
 fpsyncStatus=$?
 echo "fpsync_stop:$(date -u +%FT%T)"
 
 echo "rsync_delete_start:$(date -u +%FT%T)"
-echo "-- $(date -u +%FT%T) -- sudo rsync -r --delete --existing --ignore-existing --ignore-errors --log-file=/tmp/efs-backup-rsync.log /mnt/backups/$efsid/$interval.$backupNum/ /backup/"
-sudo rsync -r --delete --existing --ignore-existing --ignore-errors --log-file=/tmp/efs-backup-rsync.log /mnt/backups/$efsid/$interval.$backupNum/ /backup/
+echo "-- $(date -u +%FT%T) -- sudo rsync -r --delete --existing --ignore-existing --ignore-errors --log-file=/tmp/efs-backup-rsync.log /mnt/backups/$efsid/$interval.$backupNum/ /mnt/destination/"
+sudo rsync -r --delete --existing --ignore-existing --ignore-errors --log-file=/tmp/efs-backup-rsync.log /mnt/backups/$efsid/$interval.$backupNum/ /mnt/destination/
 
 echo "rsync_delete_stop:$(date -u +%FT%T)"
 

--- a/source/scripts/efs-restore-fpsync.sh
+++ b/source/scripts/efs-restore-fpsync.sh
@@ -28,6 +28,8 @@ sudo make install
 # Adding PATH
 PATH=$PATH:/usr/local/bin
 
+_security_groups=$(curl -s http://169.254.169.254/latest/meta-data/security-groups/ | tr '\n' ',')
+echo "-- $(date -u +%FT%T) -- Security Groups: ${_security_groups}"
 
 echo "-- $(date -u +%FT%T) -- sudo mkdir -p /mnt/destination"
 sudo mkdir -p /mnt/destination


### PR DESCRIPTION
I couldn't get the restore script to work. This PR does the following:

1. Change the terminology in the field labels for the EFS IDs to "Source" and "Destination"
    - the original "Source" and "Backup" were confusing when using the restore script
    - also changed the mountpoints in the code, `/backup` and `/mnt/backups` were similarly confusing
2. Add a security group to the restoration EC2 instance
    - This was required in our use case to allow access to the existing EFS containing backups and live data
3. Improve logging
    - log more info about DNS resolution
    - fix a couple of cases where the timestamp wasn't logged due to use of single instead of double quotes
    - make curl requests for instance metadata silent to remove noise from the logs
4. Fix some typos