### PR TITLE
Various fixes to backup solution

### DIFF
--- a/deployment/efs-to-efs-backup.template
+++ b/deployment/efs-to-efs-backup.template
@@ -15,6 +15,11 @@ Parameters:
     Description: Source EFS Id
     Type: String
 
+  # It will be attached to the backup instance
+  InstanceSG:
+    Description: The ID of a security group that allows access the source EFS fs
+    Type: String
+
   # Interval tag for your backups; daily, weekly, monthly
   IntervalTag:
     Description: Interval label to identify backups
@@ -127,6 +132,7 @@ Metadata:
           default: Backup Configuration
         Parameters:
           - SrcEFS
+          - InstanceSG
           - IntervalTag
           - Retain
           - FolderLabel
@@ -154,6 +160,8 @@ Metadata:
         default: Subnet IDs
       SrcEFS:
         default: Source EFS
+      InstanceSG:
+        default: Backup instance security group ID
       FolderLabel:
         default: Folder Label
       InstanceSize:
@@ -257,6 +265,7 @@ Resources:
       ImageId: !GetAtt AMIInfo.Id
       SecurityGroups:
         - !Sub ${EFSSecurityGroup}
+        - !Sub ${InstanceSG}
       InstanceType: !FindInMap [Map, !Ref "AWS::Region", !Ref InstanceSize]
       IamInstanceProfile: !Sub ${InstanceProfile}
       UserData:

--- a/deployment/efs-to-efs-backup.template
+++ b/deployment/efs-to-efs-backup.template
@@ -20,6 +20,11 @@ Parameters:
     Description: The ID of a security group that allows access the source EFS fs
     Type: String
 
+  # Will be added to the EC2 instance
+  InstanceKeyPair:
+    Description: A keypair to attach to the backup instance so SSH can be used for debugging purposes
+    Type: AWS::EC2::KeyPair::KeyName
+
   # Interval tag for your backups; daily, weekly, monthly
   IntervalTag:
     Description: Interval label to identify backups
@@ -152,6 +157,7 @@ Metadata:
         Parameters:
           - SrcEFS
           - InstanceSG
+          - InstanceKeyPair
           - IntervalTag
           - Retain
           - FolderLabel
@@ -189,6 +195,8 @@ Metadata:
         default: Source EFS
       InstanceSG:
         default: Backup instance security group ID
+      InstanceKeyPair:
+        default: Backup instance key pair name
       FolderLabel:
         default: Folder Label
       InstanceSize:
@@ -305,6 +313,8 @@ Resources:
   BackupInstanceLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
+      KeyName:
+        Ref: "InstanceKeyPair"
       ImageId: !GetAtt AMIInfo.Id
       SecurityGroups:
         - !Sub ${EFSSecurityGroup}

--- a/deployment/efs-to-efs-backup.template
+++ b/deployment/efs-to-efs-backup.template
@@ -96,7 +96,7 @@ Parameters:
     Description: VPC where the source EFS has mount targets
     Type: AWS::EC2::VPC::Id
 
-  # List of SubnetIDs for EC2, must be same AZ as of EFS Mount Targets (Choose 2)
+  # List of SubnetIDs for EC2, must be same AZ as of EFS Mount Targets (Choose 3)
   Subnets:
     Description: List of SubnetIDs for EC2, must be same AZ as of EFS Mount Targets(Choose 2)
     Type: List<AWS::EC2::Subnet::Id>
@@ -252,6 +252,14 @@ Resources:
     Properties:
       FileSystemId: !Sub ${DstEFS}
       SubnetId: !Select [ 1, !Ref Subnets ]
+      SecurityGroups:
+        - !Sub ${EFSSecurityGroup}
+
+  MountTarget2:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Sub ${DstEFS}
+      SubnetId: !Select [ 2, !Ref Subnets ]
       SecurityGroups:
         - !Sub ${EFSSecurityGroup}
 

--- a/deployment/efs-to-efs-backup.template
+++ b/deployment/efs-to-efs-backup.template
@@ -125,6 +125,15 @@ Parameters:
       - "No"
     Default: "Yes"
 
+  ProxyURL:
+    Description: The optional full URL of the proxy that provides internet access
+    Type: String
+
+  NoProxy:
+    Description: A an optional list of hosts that should not be accessed by the proxy
+    Type: String
+    Default: "169.254.169.254"
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -141,6 +150,8 @@ Metadata:
           - BackupPrefix
           - EFSMode
           - EFSEncryption
+          - ProxyURL
+          - NoProxy
       - Label:
           default: EC2 Configuration
         Parameters:
@@ -180,6 +191,10 @@ Metadata:
         default: VPC ID
       EFSEncryption:
         default: EFS Encryption
+      ProxyURL:
+        default: Proxy URL (Optional)
+      NoProxy:
+        default: No Proxy (Optional)
 
 Mappings:
   Map:
@@ -279,17 +294,75 @@ Resources:
       UserData:
         # download and run efs-backup script
           Fn::Base64: !Sub |
-           #!/bin/bash
-           sudo yum install amazon-ssm-agent -y
-           sudo /sbin/start amazon-ssm-agent
+            Content-Type: multipart/mixed; boundary="//"
+            MIME-Version: 1.0
 
-           wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-ec2-backup.sh -P /home/ec2-user
-           wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-backup-fpsync.sh -P /home/ec2-user
+            --//
+            Content-Type: text/cloud-config; charset="us-ascii"
+            MIME-Version: 1.0
+            Content-Transfer-Encoding: 7bit
+            Content-Disposition: attachment; filename="cloud-config.txt"
 
-           chmod a+x /home/ec2-user/efs-ec2-backup.sh
-           chmod a+x /home/ec2-user/efs-backup-fpsync.sh
+            #cloud-config
+            cloud_final_modules:
+            - [scripts-user, always]
 
-           /home/ec2-user/efs-ec2-backup.sh ${SrcEFS} ${DstEFS} ${IntervalTag} ${Retain} ${FolderLabel} ${BackupPrefix}
+            --//
+            Content-Type: text/x-shellscript; charset="us-ascii"
+            MIME-Version: 1.0
+            Content-Transfer-Encoding: 7bit
+            Content-Disposition: attachment; filename="userdata.txt"
+
+            #!/bin/bash
+            set -e
+
+            export {http,https}_proxy="${ProxyURL}"
+            export {HTTP,HTTPS}_PROXY="${ProxyURL}"
+            export {no_proxy,NO_PROXY}="${NoProxy}"
+
+            sudo yum install amazon-ssm-agent -y
+            sudo yum install -y jq
+
+            sudo mv /etc/init/amazon-ssm-agent.conf /etc/init/amazon-ssm-agent.conf.bak
+
+            # How many lines from the bottom of the config file to insert the proxy statements
+            insert_position=2
+
+            sudo head -n -${!insert_position} /etc/init/amazon-ssm-agent.conf.bak | sudo tee /etc/init/amazon-ssm-agent.conf
+            if [ -n "$http_proxy" ]; then
+              echo "env http_proxy=${!http_proxy}"   | sudo tee -a /etc/init/amazon-ssm-agent.conf;
+            fi
+            if [ -n "$https_proxy" ]; then
+              echo "env https_proxy=${!https_proxy}" | sudo tee -a /etc/init/amazon-ssm-agent.conf;
+            fi
+            if [ -n "$HTTP_PROXY" ]; then
+              echo "env HTTP_PROXY=${!HTTP_PROXY}"   | sudo tee -a /etc/init/amazon-ssm-agent.conf;
+            fi
+            if [ -n "$HTTPS_PROXY" ]; then
+              echo "env HTTPS_PROXY=${!HTTPS_PROXY}" | sudo tee -a /etc/init/amazon-ssm-agent.conf;
+            fi
+            if [ -n "$no_proxy" ]; then
+              echo "env no_proxy=${!no_proxy}"       | sudo tee -a /etc/init/amazon-ssm-agent.conf;
+            fi
+            if [ -n "$NO_PROXY" ]; then
+              echo "env NO_PROXY=${!NO_PROXY}"       | sudo tee -a /etc/init/amazon-ssm-agent.conf;
+            fi
+            sudo tail -n ${!insert_position} /etc/init/amazon-ssm-agent.conf.bak | sudo tee -a /etc/init/amazon-ssm-agent.conf
+
+            echo "=== Begin SSM Agent Config ==="
+            sudo cat /etc/init/amazon-ssm-agent.conf
+            echo "=== End SSM Agent Config ==="
+
+            sudo /sbin/restart amazon-ssm-agent
+
+            wget "${BackupScriptURL}" -P /home/ec2-user
+            wget "${FPSyncScriptURL}" -P /home/ec2-user
+
+            chmod a+x /home/ec2-user/efs-ec2-backup.sh
+            chmod a+x /home/ec2-user/efs-backup-fpsync.sh
+
+            /home/ec2-user/efs-ec2-backup.sh ${SrcEFS} ${DstEFS} ${IntervalTag} ${Retain} ${FolderLabel} ${BackupPrefix}
+            --//
 
   EFSAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/deployment/efs-to-efs-backup.template
+++ b/deployment/efs-to-efs-backup.template
@@ -18,7 +18,7 @@ Parameters:
   # It will be attached to the backup instance
   InstanceSG:
     Description: The ID of a security group that allows access the source EFS fs
-    Type: String
+    Type: AWS::EC2::SecurityGroup::Id
 
   # Will be added to the EC2 instance
   InstanceKeyPair:

--- a/deployment/efs-to-efs-backup.template
+++ b/deployment/efs-to-efs-backup.template
@@ -134,6 +134,16 @@ Parameters:
     Type: String
     Default: "169.254.169.254"
 
+  BackupScriptURL:
+    Description: A URL that points to the 'efs-ec2-backup.sh' script required for the template.
+    Type: String
+    Default: "https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-ec2-backup.sh"
+
+  FPSyncScriptURL:
+    Description: A URL that points to the 'efs-backup-fpsync.sh' script required for the template.
+    Type: String
+    Default: "https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-backup-fpsync.sh"
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -164,6 +174,12 @@ Metadata:
           - SuccessNotification
           - Email
           - Dashboard
+      - Label:
+          default: Debugging
+        Parameters:
+          - BackupScriptURL
+          - FPSyncScriptURL
+
     ParameterLabels:
       IntervalTag:
         default: Interval Label
@@ -195,6 +211,10 @@ Metadata:
         default: Proxy URL (Optional)
       NoProxy:
         default: No Proxy (Optional)
+      BackupScriptURL:
+        default: A URL that points to the 'efs-ec2-backup.sh'
+      FPSyncScriptURL:
+        default: A URL that points to the 'efs-backup-fpsync.sh'
 
 Mappings:
   Map:

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -36,8 +36,8 @@ sudo yum -y install nfs-utils
 
 echo "-- $(date -u +%FT%T) -- sudo yum -y groupinstall 'Development Tools'"
 sudo yum -y groupinstall "Development Tools"
-echo "-- $(date -u +%FT%T) -- wget https://s3.amazonaws.com/solutions-reference/efs-backup/latest/fpart.zip"
-wget https://s3.amazonaws.com/solutions-reference/efs-backup/latest/fpart.zip
+echo "-- $(date -u +%FT%T) -- wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip"
+wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
 unzip fpart.zip
 cd fpart-fpart-0.9.3/
 autoreconf -i

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -12,6 +12,7 @@
 # Snapshots will look like:
 # $dst/$efsid/hourly.0-3; daily.0-30; weekly.0-3; monthly.0-2
 
+set -e # Exit on error
 
 # input arguments
 source=$1 #source_ip:/prefix
@@ -36,7 +37,7 @@ sudo yum -y install nfs-utils
 
 echo "-- $(date -u +%FT%T) -- sudo yum -y groupinstall 'Development Tools'"
 sudo yum -y groupinstall "Development Tools"
-echo "-- $(date -u +%FT%T) -- wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip"
+echo "-- $(date -u +%FT%T) -- wget https://s3.amazonaws.com/solutions-reference/efs-backup/latest/fpart.zip"
 wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
 unzip fpart.zip
 cd fpart-fpart-0.9.3/

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -21,7 +21,6 @@ interval=$3
 retain=$4
 efsid=$5
 
-
 echo "## input from user ##"
 echo "source: ${source}"
 echo "destination: ${destination}"
@@ -89,12 +88,7 @@ if [ ! -d /mnt/backups/$efsid ]; then
   echo "-- $(date -u +%FT%T) --  sudo chmod 700 /mnt/backups/$efsid"
   sudo chmod 700 /mnt/backups/$efsid
 fi
-# if [ ! -d /mnt/backups/efsbackup-logs ]; then
-#   echo "-- $(date -u +%FT%T) --  sudo mkdir -p /mnt/backups/efsbackup-logs"
-#   sudo mkdir -p /mnt/backups/efsbackup-logs
-#   echo "-- $(date -u +%FT%T) --  sudo chmod 700 /mnt/backups/efsbackup-logs"
-#   sudo chmod 700 /mnt/backups/efsbackup-logs
-# fi
+
 echo "-- $(date -u +%FT%T) --  sudo rm /tmp/efs-backup.log"
 sudo rm /tmp/efs-backup.log
 
@@ -125,4 +119,4 @@ echo "Stating backup....."
 echo "-- $(date -u +%FT%T) --  sudo \"PATH=$PATH\" /usr/local/bin/fpsync -n $_thread_count -o \"-a --stats --numeric-ids --log-file=/tmp/efs-backup.log\" /backup/ /mnt/backups/$efsid/$interval.0/"
 sudo "PATH=$PATH" /usr/local/bin/fpsync -n $_thread_count -v -o "-a --stats --numeric-ids --log-file=/tmp/efs-backup.log" /backup/ /mnt/backups/$efsid/$interval.0/ 1>/tmp/efs-fpsync.log
 fpsyncStatus=$?
-echo "fpsync exit code was: [$fpsyncStatus]"
+echo "-- $(date -u +%FT%T) --  fpsync exit code was: [$fpsyncStatus]"

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -38,7 +38,7 @@ sudo yum -y install nfs-utils
 echo "-- $(date -u +%FT%T) -- sudo yum -y groupinstall 'Development Tools'"
 sudo yum -y groupinstall "Development Tools"
 echo "-- $(date -u +%FT%T) -- wget https://s3.amazonaws.com/solutions-reference/efs-backup/latest/fpart.zip"
-wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
+wget https://s3.amazonaws.com/solutions-reference/efs-backup/latest/fpart.zip
 unzip fpart.zip
 cd fpart-fpart-0.9.3/
 autoreconf -i

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -124,4 +124,4 @@ echo "Stating backup....."
 echo "-- $(date -u +%FT%T) --  sudo \"PATH=$PATH\" /usr/local/bin/fpsync -n $_thread_count -o \"-a --stats --numeric-ids --log-file=/tmp/efs-backup.log\" /backup/ /mnt/backups/$efsid/$interval.0/"
 sudo "PATH=$PATH" /usr/local/bin/fpsync -n $_thread_count -v -o "-a --stats --numeric-ids --log-file=/tmp/efs-backup.log" /backup/ /mnt/backups/$efsid/$interval.0/ 1>/tmp/efs-fpsync.log
 fpsyncStatus=$?
-exit $fpsyncStatus
+echo "fpsync exit code was: [$fpsyncStatus]"

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -90,7 +90,7 @@ if [ ! -d /mnt/backups/$efsid ]; then
 fi
 
 echo "-- $(date -u +%FT%T) --  sudo rm /tmp/efs-backup.log"
-sudo rm /tmp/efs-backup.log
+sudo rm -f /tmp/efs-backup.log
 
 # ECU Count per instance
 # c4.large = 8

--- a/source/scripts/efs-ec2-backup.sh
+++ b/source/scripts/efs-ec2-backup.sh
@@ -92,8 +92,6 @@ else
   # parameters : [_src_mount_ip, _dst_mount_ip, _interval, _retain, _folder_label, _backup_window]
   #
   echo "-- $(date -u +%FT%T) -- running EFS backup script"
-  # _timeout_val=$(((${_backup_window}-1)*60)) # timeout 1 minute less than given window -> timeout in SSM
-  # timeout --preserve-status --signal=2 ${_timeout_val} ./efs-backup-fpsync.sh ${_src_mount_ip}:/ ${_dst_mount_ip}:/ ${_interval} ${_retain} ${_folder_label}
   /home/ec2-user/efs-backup-fpsync.sh ${_src_mount_ip}:${_backup_prefix} ${_dst_mount_ip}:/ ${_interval} ${_retain} ${_folder_label} || false
 fi
 

--- a/source/scripts/efs-ec2-backup.sh
+++ b/source/scripts/efs-ec2-backup.sh
@@ -14,8 +14,8 @@
 function cleanup {
   # Fetch instance IAM role credentials (should be automatically injected but doesn't seem to work during cloud-init)
   sudo yum install -y jq
-  ROLE_IAM=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/)
-  CREDENTIAL_JSON=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/${ROLE_IAM})
+  ROLE_IAM=$(curl --show-error --fail http://169.254.169.254/latest/meta-data/iam/security-credentials/)
+  CREDENTIAL_JSON=$(curl --show-error --fail http://169.254.169.254/latest/meta-data/iam/security-credentials/${ROLE_IAM})
   STATUS=$(echo "${CREDENTIAL_JSON}" | jq -r .Code)
   echo "Got status [${STATUS}] when fetching credentials"
   export AWS_ACCESS_KEY_ID=$(echo "${CREDENTIAL_JSON}" | jq -r .AccessKeyId)

--- a/source/scripts/efs-ec2-backup.sh
+++ b/source/scripts/efs-ec2-backup.sh
@@ -75,6 +75,14 @@ else
   /home/ec2-user/efs-backup-fpsync.sh ${_src_mount_ip}:${_backup_prefix} ${_dst_mount_ip}:/ ${_interval} ${_retain} ${_folder_label}
 fi
 
+# Fetch instance IAM role credentials (should be automatically injected but doesn't seem to work during cloud-init)
+sudo yum install -y jq
+ROLE_IAM=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/)
+CREDENTIAL_JSON=$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/${ROLE_IAM})
+STATUS=$(echo "${CREDENTIAL_JSON}" | jq -r .Code)
+echo "Got status [${STATUS}] when fetching credentials"
+export AWS_ACCESS_KEY_ID=$(echo "${CREDENTIAL_JSON}" | jq -r .AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "${CREDENTIAL_JSON}" | jq -r .SecretAccessKey)
 
 #
 # changing auto scaling capacity

--- a/source/scripts/efs-ec2-backup.sh
+++ b/source/scripts/efs-ec2-backup.sh
@@ -17,7 +17,7 @@ function cleanup {
   ROLE_IAM=$(curl --show-error --fail http://169.254.169.254/latest/meta-data/iam/security-credentials/)
   CREDENTIAL_JSON=$(curl --show-error --fail http://169.254.169.254/latest/meta-data/iam/security-credentials/${ROLE_IAM})
   STATUS=$(echo "${CREDENTIAL_JSON}" | jq -r .Code)
-  echo "Got status [${STATUS}] when fetching credentials"
+  echo "-- $(date -u +%FT%T) -- Got status [${STATUS}] when fetching credentials"
   export AWS_ACCESS_KEY_ID=$(echo "${CREDENTIAL_JSON}" | jq -r .AccessKeyId)
   export AWS_SECRET_ACCESS_KEY=$(echo "${CREDENTIAL_JSON}" | jq -r .SecretAccessKey)
 

--- a/source/scripts/efs-ec2-backup.sh
+++ b/source/scripts/efs-ec2-backup.sh
@@ -12,15 +12,6 @@
 # author: aws-solutions-builder@
 
 function cleanup {
-  # Fetch instance IAM role credentials (should be automatically injected but doesn't seem to work during cloud-init)
-  sudo yum install -y jq
-  ROLE_IAM=$(curl --show-error --fail http://169.254.169.254/latest/meta-data/iam/security-credentials/)
-  CREDENTIAL_JSON=$(curl --show-error --fail http://169.254.169.254/latest/meta-data/iam/security-credentials/${ROLE_IAM})
-  STATUS=$(echo "${CREDENTIAL_JSON}" | jq -r .Code)
-  echo "-- $(date -u +%FT%T) -- Got status [${STATUS}] when fetching credentials"
-  export AWS_ACCESS_KEY_ID=$(echo "${CREDENTIAL_JSON}" | jq -r .AccessKeyId)
-  export AWS_SECRET_ACCESS_KEY=$(echo "${CREDENTIAL_JSON}" | jq -r .SecretAccessKey)
-
   #
   # changing auto scaling capacity
   # parameters : [_asg_name]


### PR DESCRIPTION
We were having some issues getting [the AWS reference efs-to-efs backup solution](https://docs.aws.amazon.com/solutions/latest/efs-to-efs-backup/welcome.html) to work out of the box in our AWS environment so we made some fixes to get it working that can be shared with the wider community.

I hope these fixes can help others!

**New Features**
- Adds support for HTTP proxies
- Adds support for adding a keypair to the backup EC2 instance
- Can now use three mount points for the backup EFS volume
- Can attach a custom security group to the backup EC2 instance
- Fix issue where backup script would exit before reporting finished state to orchestrator
- Made backup script more robust
- Misc. cleanup and various small fixes

**Still Needs To Be Done**
- I couldn't get the tests to work but I don't have time to debug that at the moment
- I haven't looked at the restore scripts yet, they probably won't work with a proxy. I'll have to look at that later.