### PR TITLE
- remove deletion flag

### DIFF
--- a/source/scripts/efs-ec2-restore.sh
+++ b/source/scripts/efs-ec2-restore.sh
@@ -104,7 +104,7 @@ else
   aws s3 cp /tmp/efs-restore.log s3://${_s3bucket}/efs-restore-logs/${_folder_label}-${_interval}.${_backup_num}-restore-fpsync-`date +%Y%m%d-%H%M`.log
   echo "upload restore fpsync logs to S3, status: $?"
   echo "-- $(date -u +%FT%T) -- upload efs restore rsync logs to S3 bucket"
-  aws s3 cp /tmp/efs-restore-rsync.log s3://${_s3bucket}/efs-restore-logs/${_folder_label}-${_interval}.${_backup_num}-restore-rsync-delete-`date +%Y%m%d-%H%M`.log
+  aws s3 cp /tmp/efs-restore-rsync.log s3://${_s3bucket}/efs-restore-logs/${_folder_label}-${_interval}.${_backup_num}-restore-rsync-`date +%Y%m%d-%H%M`.log
   echo "upload restore rsync logs to S3, status: $?"
 
   #
@@ -123,15 +123,15 @@ else
   _ttfs=$(cat /tmp/efs-restore.log | grep 'Total transferred file size' | awk '{ttfs += $8} END {print ttfs}')
   echo "Total transferred file size: ${_ttfs}"
 
-  # timestamps for (fpsync) and (rsync --delete) file operations
+  # timestamps for (fpsync) and (rsync) file operations
   _fpsync_start=$(cat /var/log/cloud-init-output.log | grep 'fpsync_start' | cut -d: -f2-)
   echo "fpsync start time: ${_fpsync_start}"
   _fpsync_stop=$(cat /var/log/cloud-init-output.log | grep 'fpsync_stop' | cut -d: -f2-)
   echo "fpsync start time: ${_fpsync_stop}"
-  _rsync_delete_start=$(cat /var/log/cloud-init-output.log | grep 'rsync_delete_start' | cut -d: -f2-)
-  echo "rsync delete start: ${_rsync_delete_start}"
-  _rsync_delete_stop=$(cat /var/log/cloud-init-output.log | grep 'rsync_delete_stop' | cut -d: -f2-)
-  echo "rsync delete stop: ${_rsync_delete_stop}"
+  _rsync_start=$(cat /var/log/cloud-init-output.log | grep 'rsync_start' | cut -d: -f2-)
+  echo "rsync start: ${_rsync_start}"
+  _rsync_stop=$(cat /var/log/cloud-init-output.log | grep 'rsync_stop' | cut -d: -f2-)
+  echo "rsync stop: ${_rsync_stop}"
 
 
   _rtime=$(date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/source/scripts/efs-restore-fpsync.sh
+++ b/source/scripts/efs-restore-fpsync.sh
@@ -75,10 +75,10 @@ sudo "PATH=$PATH" /usr/local/bin/fpsync -n $_thread_count -v -o "-a --stats --nu
 fpsyncStatus=$?
 echo "fpsync_stop:$(date -u +%FT%T)"
 
-echo "rsync_delete_start:$(date -u +%FT%T)"
-echo "-- $(date -u +%FT%T) -- sudo rsync -r --delete --existing --ignore-existing --ignore-errors --log-file=/tmp/efs-restore-rsync.log /mnt/backups/$efsid/$interval.$backupNum/ /mnt/source/"
-sudo rsync -r --delete --existing --ignore-existing --ignore-errors --log-file=/tmp/efs-restore-rsync.log /mnt/backups/$efsid/$interval.$backupNum/ /mnt/source/
+echo "rsync_start:$(date -u +%FT%T)"
+echo "-- $(date -u +%FT%T) -- sudo rsync -r --existing --ignore-existing --ignore-errors --log-file=/tmp/efs-restore-rsync.log /mnt/backups/$efsid/$interval.$backupNum/ /mnt/source/"
+sudo rsync -r --existing --ignore-existing --ignore-errors --log-file=/tmp/efs-restore-rsync.log /mnt/backups/$efsid/$interval.$backupNum/ /mnt/source/
 
-echo "rsync_delete_stop:$(date -u +%FT%T)"
+echo "rsync_stop:$(date -u +%FT%T)"
 
 exit $fpsyncStatus


### PR DESCRIPTION
When restoring, it is often seen as not best practice to remove new content that differs from backup, but to evaluate that content after a restore. Please consider these changes.

With these changes, content can be in the source EFS volume that is not in the backup EFS volume, that isn't removed after a restore. However, files are restored that were removed from source EFS that are still available in backup EFS.