### PR TITLE
Fpart

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,17 +104,6 @@ sed -i '' -e s/%TEMPLATE_BUCKET_NAME%/solutions-reference/g deployment/dist/efs-
 Updating version number in the template with v1.0
 sed -i '' -e s/%VERSION%/v1.0/g deployment/dist/efs-to-efs-backup.template
 sed -i '' -e s/%VERSION%/v1.0/g deployment/dist/efs-to-efs-restore.template
-Download the fpart package from github
-curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip fpart.zip
-https://codeload.github.com/martymac/fpart/zip/fpart-0.9.3
-Resolving codeload.github.com (codeload.github.com)...
-Connecting to codeload.github.com (codeload.github.com)|... connected.
-HTTP request sent, awaiting response... 200 OK
-Length: unspecified [application/zip]
-Saving to: 'fpart-0.9.3.zip'
-0K .......... .......... .......... .......... .......... 14.3M
-50K .......... .......... .... 15.4M=0.005s
-(14.6 MB/s) - 'fpart-0.9.3.zip' saved [76187]
 cp source/scripts/efs-* deployment/dist
 
 $ ls -l deployment/dist     
@@ -125,7 +114,6 @@ $ ls -l deployment/dist
 -rw-r--r--      efs-restore-fpsync.sh
 -rw-r--r--      efs-restore.template
 -rw-r--r--      efs_to_efs_backup.zip
--rw-r--r--      fpart.zip
 -rw-r--r--      amilookup.zip
 ```
 ***

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Updating version number in the template with v1.0
 sed -i '' -e s/%VERSION%/v1.0/g deployment/dist/efs-to-efs-backup.template
 sed -i '' -e s/%VERSION%/v1.0/g deployment/dist/efs-to-efs-restore.template
 Download the fpart package from github
-wget https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip fpart.zip
+curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip fpart.zip
 https://codeload.github.com/martymac/fpart/zip/fpart-0.9.3
 Resolving codeload.github.com (codeload.github.com)...
 Connecting to codeload.github.com (codeload.github.com)|... connected.

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -45,9 +45,9 @@ echo "sed -i '' -e $replace deployment/dist/efs-to-efs-restore.template"
 sed -i '' -e $replace deployment/dist/efs-to-efs-restore.template
 
 echo 'Download the fpart package from github'
-echo 'wget https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip deployment/dist/fpart.zip'
-wget https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip deployment/dist/fpart.zip
+echo 'curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip deployment/dist/fpart.zip'
+curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip deployment/dist/fpart.zip
 
 echo 'Download the AMI ID lookup package from S3'
-echo 'wget https://s3.amazonaws.com/cloudformation-examples/lambda/amilookup.zip; mv amilookup.zip deployment/dist/amilookup.zip'
-wget https://s3.amazonaws.com/cloudformation-examples/lambda/amilookup.zip; mv amilookup.zip deployment/dist/amilookup.zip
+echo 'curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/cloudformation-examples/lambda/amilookup.zip; mv amilookup.zip deployment/dist/amilookup.zip'
+curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/cloudformation-examples/lambda/amilookup.zip; mv amilookup.zip deployment/dist/amilookup.zip

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -44,10 +44,6 @@ sed -i '' -e $replace deployment/dist/efs-to-efs-backup.template
 echo "sed -i '' -e $replace deployment/dist/efs-to-efs-restore.template"
 sed -i '' -e $replace deployment/dist/efs-to-efs-restore.template
 
-echo 'Download the fpart package from github'
-echo 'curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip deployment/dist/fpart.zip'
-curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://github.com/martymac/fpart/archive/fpart-0.9.3.zip; mv fpart-0.9.3.zip deployment/dist/fpart.zip
-
 echo 'Download the AMI ID lookup package from S3'
 echo 'curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/cloudformation-examples/lambda/amilookup.zip; mv amilookup.zip deployment/dist/amilookup.zip'
 curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/cloudformation-examples/lambda/amilookup.zip; mv amilookup.zip deployment/dist/amilookup.zip

--- a/deployment/efs-to-efs-backup.template
+++ b/deployment/efs-to-efs-backup.template
@@ -266,8 +266,8 @@ Resources:
            sudo yum install amazon-ssm-agent -y
            sudo /sbin/start amazon-ssm-agent
 
-           wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-ec2-backup.sh -P /home/ec2-user
-           wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-backup-fpsync.sh -P /home/ec2-user
+           curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-ec2-backup.sh -P /home/ec2-user
+           curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-backup-fpsync.sh -P /home/ec2-user
 
            chmod a+x /home/ec2-user/efs-ec2-backup.sh
            chmod a+x /home/ec2-user/efs-backup-fpsync.sh

--- a/deployment/efs-to-efs-restore.template
+++ b/deployment/efs-to-efs-restore.template
@@ -204,8 +204,8 @@ Resources:
           Fn::Base64: !Sub |
             #!/bin/bash
 
-            wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-ec2-restore.sh -P /home/ec2-user
-            wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-restore-fpsync.sh -P /home/ec2-user
+            curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-ec2-restore.sh -P /home/ec2-user
+            curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/efs-restore-fpsync.sh -P /home/ec2-user
 
             chmod a+x /home/ec2-user/efs-ec2-restore.sh
             chmod a+x /home/ec2-user/efs-restore-fpsync.sh

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -34,16 +34,8 @@ sudo yum -y update
 echo "-- $(date -u +%FT%T) -- sudo yum -y install nfs-utils"
 sudo yum -y install nfs-utils
 
-echo "-- $(date -u +%FT%T) -- sudo yum -y groupinstall 'Development Tools'"
-sudo yum -y groupinstall "Development Tools"
-echo "-- $(date -u +%FT%T) -- curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip"
-curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
-unzip fpart.zip
-cd fpart-fpart-0.9.3/
-autoreconf -i
-./configure
-make
-sudo make install
+echo "-- $(date -u +%FT%T) -- sudo yum -y install fpart"
+sudo yum -y install fpart
 
 # Adding PATH
 PATH=$PATH:/usr/local/bin

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -38,7 +38,7 @@ echo "-- $(date -u +%FT%T) -- sudo yum -y install fpart"
 sudo yum -y install fpart
 
 # Adding PATH
-PATH=$PATH:/usr/local/bin
+PATH=$PATH:/usr/local/bin:/usr/bin
 
 echo "-- $(date -u +%FT%T) -- sudo mkdir /backup"
 sudo mkdir /backup
@@ -113,7 +113,7 @@ fi
 
 # start fpsync process
 echo "Stating backup....."
-echo "-- $(date -u +%FT%T) --  sudo \"PATH=$PATH\" /usr/local/bin/fpsync -n $_thread_count -o \"-a --stats --numeric-ids --log-file=/tmp/efs-backup.log\" /backup/ /mnt/backups/$efsid/$interval.0/"
-sudo "PATH=$PATH" /usr/local/bin/fpsync -n $_thread_count -v -o "-a --stats --numeric-ids --log-file=/tmp/efs-backup.log" /backup/ /mnt/backups/$efsid/$interval.0/ 1>/tmp/efs-fpsync.log
+echo "-- $(date -u +%FT%T) --  sudo \"PATH=$PATH\" fpsync -n $_thread_count -o \"-a --stats --numeric-ids --log-file=/tmp/efs-backup.log\" /backup/ /mnt/backups/$efsid/$interval.0/"
+sudo "PATH=$PATH" fpsync -n $_thread_count -v -o "-a --stats --numeric-ids --log-file=/tmp/efs-backup.log" /backup/ /mnt/backups/$efsid/$interval.0/ 1>/tmp/efs-fpsync.log
 fpsyncStatus=$?
 exit $fpsyncStatus

--- a/source/scripts/efs-backup-fpsync.sh
+++ b/source/scripts/efs-backup-fpsync.sh
@@ -36,8 +36,8 @@ sudo yum -y install nfs-utils
 
 echo "-- $(date -u +%FT%T) -- sudo yum -y groupinstall 'Development Tools'"
 sudo yum -y groupinstall "Development Tools"
-echo "-- $(date -u +%FT%T) -- wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip"
-wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
+echo "-- $(date -u +%FT%T) -- curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip"
+curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
 unzip fpart.zip
 cd fpart-fpart-0.9.3/
 autoreconf -i

--- a/source/scripts/efs-restore-fpsync.sh
+++ b/source/scripts/efs-restore-fpsync.sh
@@ -14,16 +14,8 @@ sudo yum -y update
 echo "-- $(date -u +%FT%T) -- sudo yum -y install nfs-utils"
 sudo yum -y install nfs-utils
 
-echo "-- $(date -u +%FT%T) -- sudo yum -y groupinstall 'Development Tools'"
-sudo yum -y groupinstall "Development Tools"
-echo "-- $(date -u +%FT%T) -- curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip"
-curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
-unzip fpart.zip
-cd fpart-fpart-0.9.3/
-autoreconf -i
-./configure
-make
-sudo make install
+echo "-- $(date -u +%FT%T) -- sudo yum -y install fpart
+sudo yum -y install fpart 
 
 # Adding PATH
 PATH=$PATH:/usr/local/bin

--- a/source/scripts/efs-restore-fpsync.sh
+++ b/source/scripts/efs-restore-fpsync.sh
@@ -18,7 +18,7 @@ echo "-- $(date -u +%FT%T) -- sudo yum -y install fpart
 sudo yum -y install fpart 
 
 # Adding PATH
-PATH=$PATH:/usr/local/bin
+PATH=$PATH:/usr/local/bin:/usr/bin
 
 
 echo '-- $(date -u +%FT%T) -- sudo mkdir /mnt/source'
@@ -62,8 +62,8 @@ fi
 
 # running fpsync in reverse direction to restore
 echo "fpsync_start:$(date -u +%FT%T)"
-echo "-- $(date -u +%FT%T) -- sudo \"PATH=$PATH\" /usr/local/bin/fpsync -n $_thread_count -v -o \"-a --stats --numeric-ids --log-file=/tmp/efs-restore.log\" /mnt/backups/$efsid/$interval.$backupNum/ /mnt/source/"
-sudo "PATH=$PATH" /usr/local/bin/fpsync -n $_thread_count -v -o "-a --stats --numeric-ids --log-file=/tmp/efs-restore.log" /mnt/backups/$efsid/$interval.$backupNum/ /mnt/source/
+echo "-- $(date -u +%FT%T) -- sudo \"PATH=$PATH\" fpsync -n $_thread_count -v -o \"-a --stats --numeric-ids --log-file=/tmp/efs-restore.log\" /mnt/backups/$efsid/$interval.$backupNum/ /mnt/source/"
+sudo "PATH=$PATH" fpsync -n $_thread_count -v -o "-a --stats --numeric-ids --log-file=/tmp/efs-restore.log" /mnt/backups/$efsid/$interval.$backupNum/ /mnt/source/
 fpsyncStatus=$?
 echo "fpsync_stop:$(date -u +%FT%T)"
 

--- a/source/scripts/efs-restore-fpsync.sh
+++ b/source/scripts/efs-restore-fpsync.sh
@@ -16,8 +16,8 @@ sudo yum -y install nfs-utils
 
 echo "-- $(date -u +%FT%T) -- sudo yum -y groupinstall 'Development Tools'"
 sudo yum -y groupinstall "Development Tools"
-echo "-- $(date -u +%FT%T) -- wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip"
-wget https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
+echo "-- $(date -u +%FT%T) -- curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip"
+curl --connect-timeout 5 --speed-time 5 --retry 10  --retry-delay 5 -s -O https://s3.amazonaws.com/%TEMPLATE_BUCKET_NAME%/efs-backup/latest/fpart.zip
 unzip fpart.zip
 cd fpart-fpart-0.9.3/
 autoreconf -i


### PR DESCRIPTION
t is now availabe in Amazon Linux's repos. There is no need to compile fpart from source anymore.

[ec2-user@ip-172-31-94-142 ~]$ cat /etc/os-release
NAME="Amazon Linux AMI"
VERSION="2018.03"
ID="amzn"
ID_LIKE="rhel fedora"
VERSION_ID="2018.03"
PRETTY_NAME="Amazon Linux AMI 2018.03"
ANSI_COLOR="0;33"
CPE_NAME="cpe:/o:amazon:linux:2018.03:ga"
HOME_URL="http://aws.amazon.com/amazon-linux-ami/"
[ec2-user@ip-172-31-94-142 ~]$ sudo yum info fpart
Loaded plugins: priorities, update-motd, upgrade-helper
Available Packages
Name        : fpart
Arch        : x86_64
Version     : 1.0.0
Release     : 1.0.amzn1
Size        : 45 k
Repo        : amzn-updates/latest
Summary     : Fpart is a tool that sorts files and packs them into bags.
URL         : http://contribs.martymac.org
License     : BSD
Description : Fpart is a tool that helps you sort file trees and pack them into bags (called
            : "partitions"). It is developped in C and available under the BSD license.
            :
            : It splits a list of directories and file trees into a certain number of
            : partitions, trying to produce partitions with the same size and number of
            : files. It can also produce partitions with a given number of files or a limited
            : siz