### PR TITLE
Export to complete security group wiring

### DIFF
--- a/deployment/efs-to-efs-backup.template
+++ b/deployment/efs-to-efs-backup.template
@@ -658,3 +658,7 @@ Outputs:
   AmiId:
     Description: Ami Id vended in template
     Value: !GetAtt AMIInfo.Id
+
+  EFSSecurityGroup:
+    Description: Backup EFS security group
+    Value: !Ref EFSSecurityGroup


### PR DESCRIPTION
Without this export, addition of the `EFSSecurityGroup` into the source EFS security group must be done manually using AWS CLI. This export will allow the backup stack to be included as a nested stack in a complete solution without resorting to AWS CLI.